### PR TITLE
Removing unused sections of reverseproxy

### DIFF
--- a/reverseproxy
+++ b/reverseproxy
@@ -50,46 +50,6 @@ server {
 		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	}
 
-#	location ^~ /transmission {
-#      
-#          proxy_set_header X-Real-IP $remote_addr;
-#          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-#          proxy_set_header Host $http_host;
-#          proxy_set_header X-NginX-Proxy true;
-#          proxy_http_version 1.1;
-#          proxy_set_header Connection "";
-#          proxy_pass_header X-Transmission-Session-Id;
-#          add_header   Front-End-Https   on;
-#      
-#          location /transmission/rpc {
-#              proxy_pass http://transmission;
-#          }
-#      
-#          location /transmission/web/ {
-#              proxy_pass http://transmission;
-#          }
-#      
-#          location /transmission/upload {
-#              proxy_pass http://transmission;
-#          }
-#      
-#          location /transmission/web/style/ {
-#              alias /usr/share/transmission/web/style/;
-#          }
-#      
-#          location /transmission/web/javascript/ {
-#              alias /usr/share/transmission/web/javascript/;
-#          }
-#      
-#          location /transmission/web/images/ {
-#              alias /usr/share/transmission/web/images/;
-#          }
-#          
-#          location /transmission/ {
-#              return 301 https://$server_name/transmission/web;
-#          }
-#	}
-
 	location /guac {
 		proxy_pass http://192.168.1.6:8080/guacamole;
 		proxy_buffering off;
@@ -118,6 +78,7 @@ server {
 		auth_basic_user_file /etc/nginx/.htpasswd;    
 	}
 	
+	# Currently inactive (replace with cloud document server and set up sync on Windows desktop?)
 	location /docs/ {
 		proxy_pass http://192.168.1.99:8000/;
 		proxy_set_header    X-Forwarded-Server $host;
@@ -127,6 +88,7 @@ server {
 		auth_basic_user_file /etc/nginx/.htpasswd;
 	}
 
+	# Inactive - keep for record of nGinx settings for serving motion streams (could use with a RPi and camera?)
 	location /cam {
 		proxy_pass http://192.168.1.65:8081;
 		proxy_buffering off;
@@ -153,29 +115,6 @@ server {
 	location / {
 		proxy_pass	http://192.168.1.4:8888/;
 		proxy_set_header	Host $host;
-		proxy_set_header        X-Real-IP $remote_addr;
-		proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-		proxy_connect_timeout   150;
-		proxy_send_timeout      100;
-		proxy_read_timeout      100;
-		proxy_buffers           4 32k;
-		client_max_body_size    500m;
-		client_body_buffer_size 128k;
-	}
-
-	location ~ /.well-known {
-		allow all;  
-	}
-
-}
-
-server {
-	listen   443;
-	server_name oldgit.153.duckdns.org;
-	root /var/www/html;
-	location / {
-		proxy_pass              http://192.168.1.219:8081/;
-		proxy_set_header        Host $host;
 		proxy_set_header        X-Real-IP $remote_addr;
 		proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
 		proxy_connect_timeout   150;
@@ -264,19 +203,4 @@ server {
 		allow all;  
 	}
 
-}
-
-server {
-	listen 443 ssl;
-	server_name watchlist.153.duckdns.org;
-	root /var/www/html;
-
-	location / {
-		proxy_pass http://192.168.1.82:8000/;
-		proxy_set_header Host $host; 
-	}
-
-	location ~ /.well-known {
-		allow all;  
-	}
 }


### PR DESCRIPTION
Removing the commented out (unused) transmission lines. Still need to set lychee, searx, gitlab, sickrage, couchpotato and maybe a document server up.